### PR TITLE
Minor message tweaks

### DIFF
--- a/src/lib/cfg.cpp
+++ b/src/lib/cfg.cpp
@@ -127,6 +127,8 @@ void cfg::init_bot() {
 		return; // TODO
 	}
 
+	write_down_slashcommands();
+
 	std::lock_guard L(cfg_values_mutex);
 
 	std::cout << "Setting up the guild count updater.\n";

--- a/src/lib/temp_vc_handler.cpp
+++ b/src/lib/temp_vc_handler.cpp
@@ -55,11 +55,12 @@ dpp::coroutine <> temp_vc_create_owner_msg(const dpp::channel& channel) {
 		.set_author(fmt::format("This VC belongs to {}.", user.username), user.get_url(), user.get_avatar_url())
 		.add_field(
 			"You're able to edit the channel!",
-			"Use a subcommand of the `/set` command to change the name, limit, or bitrate of your channel to whatever value your soul desires. See `/help` (not to be confused with \"seek help\") for more information."
+			fmt::format("Use a subcommand of the `/tempvc` command to change the name, limit, or bitrate of your channel to whatever value your soul desires. "
+			   " You can also use it to restrict users' access to them. See {} (not to be confused with \"seek help\") for more information.", slash::get_mention("help"))
 		)
 		.set_footer(
 			dpp::embed_footer()
-			.set_text("Use the button bellow to toggle the temporary VC creation ping on/off. Have fun!")
+			.set_text("Use the button below to toggle the temporary VC creation ping on/off. Have fun!")
 		);
 	const dpp::message message = dpp::message(channel.id, user.get_mention()).add_embed(temp_ping_embed).add_component(
 		dpp::component().add_component(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -444,11 +444,11 @@ int main(const int argc, char** argv) {
 		else if (cmd_name == "reload") {
 			log("Started reloading...");
 			cfg::read_config();
-			cfg::init_bot();
 			for (const dpp::guild* guild : dpp::get_guild_cache()->get_container() | std::views::values) {
 				cfg::init_guild_channels(guild->id, guild->channels);
 			}
 			cfg::init_db_data();
+			cfg::write_down_slashcommands();
 			if (!db::connection_successful()) {
 				event.reply(dpp::message("COULDN'T CONNECT TO THE DATABASE! THIS IS A DISASTER! RUN WHILE YOU CAN!").set_flags(dpp::m_ephemeral), error_callback);
 				log("Reload: COULDN'T CONNECT TO THE DATABASE! THIS IS A DISASTER! RUN WHILE YOU CAN!");


### PR DESCRIPTION
- Fixed the /help message displaying errors instead of command mentions
- Updated the "You own this channel!" message
- Prevented the bot from re-initialising itself when using `/reload`